### PR TITLE
Add multifile modals support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.3.0](https://github.com/mokkapps/changelog-generator-demo/compare/v2.2.1...v2.3.0) (2024-06-22)
+
+
+### Features
+
+* **files-modal:** add modal to change extension of batch of files ([#62](https://github.com/Falcion/UNITADE.md/issues/62)) ([875ce27](https://github.com/mokkapps/changelog-generator-demo/commits/875ce2782071d25e4b9c30dc95bc118645cbeee8))
+* **files-rename:** add modal to rename multiple files ([#62](https://github.com/Falcion/UNITADE.md/issues/62)) ([e535c36](https://github.com/mokkapps/changelog-generator-demo/commits/e535c364691381ca56890155538886d1126d9751))
+
+
+### Build system
+
+* **clone:** add .BAT script to clone dev-plugin in test-vault directly ([f6233fc](https://github.com/mokkapps/changelog-generator-demo/commits/f6233fce6bae9ef1665673cb1dcdf25ef59e54a5))
+
 ### [2.2.1](https://github.com/mokkapps/changelog-generator-demo/compare/v2.2.0...v2.2.1) (2024-05-14)
 
 

--- a/clone.bat
+++ b/clone.bat
@@ -1,0 +1,16 @@
+@echo off
+
+REM Define the source and destination file paths
+SET ""
+SET ""
+
+REM Copy the file
+COPY "%source_file%" "%target_file%" /Y
+
+REM Check if the copy operation was successful
+IF ERRORLEVEL 0 (
+    ECHO File copied successfully.
+) ELSE (
+    ECHO Error: File copy failed.
+    EXIT /B 1
+)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "unitade",
     "name": "UNITADE.md",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "minAppVersion": "1.0.0",
     "description": "Effortlessly treat any file extension as note, organize diverse file formats in your vault and take advancements in control of extension system even with custom modals.",
     "author": "Falcion",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "unitade",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unitade",
-      "version": "2.2.1",
+      "version": "2.3.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "os": [
         "linux",
@@ -68,6 +69,10 @@
         "typescript": "^5.4.5",
         "unicorn": "^0.0.1",
         "url": "^0.11.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unitade",
   "displayName": "UNITADE.md",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A plugin for note-taking app Obsidian™ which allows you to treat any file extension as markdown note-file",
   "main": "main.ts",
   "markdown": "github",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "release:major": "standard-version --release-as major",
     "generate-version-json": "node scripts/js/generate-version-json.js",
     "cli": ".\\gh.cli.sh",
-    "build": "tsc -noEmit -skipLibCheck --esModuleInterop source/main.ts && node esbuild.config.mjs production"
+    "build": "tsc -noEmit -skipLibCheck --esModuleInterop source/main.ts && node esbuild.config.mjs production && clone.bat"
   },
   "repository": {
     "type": "git",

--- a/source/components/files-edit.ts
+++ b/source/components/files-edit.ts
@@ -38,8 +38,6 @@ import MODALES_LOCALE from "./../locales/modals.text";
 export class TFilesEdit extends Modal {
     private _new_extension: string = 'md';
 
-    private _files: TAbstractFile[] = [];
-
     private _integration: boolean;
 
     constructor(
@@ -49,10 +47,6 @@ export class TFilesEdit extends Modal {
         super(plugin.app);
 
         this.target ??= [this.plugin.app.vault.getRoot()];
-
-        for (const item of target) {
-            this._files.push(item);
-        }
 
         this._integration = false;
     }
@@ -147,7 +141,7 @@ export class TFilesEdit extends Modal {
             this.plugin.uptSettings(next);
         }
 
-        this._files.forEach(async (file) => {
+        this.target.forEach(async (file) => {
             const filename = file.path.split('/').last()!
             const filepath = file.path.split('/').slice(0, -1).join('/');
 
@@ -162,7 +156,7 @@ export class TFilesEdit extends Modal {
     }
 
     private __generateDisplayInfo(): string {
-        return this._files.map(file => {
+        return this.target.map(file => {
             const filename = file.path.split('/').last()!;
             const filepath = file.path.split('/').slice(0, -1).join('/');
             const extension = filename.split('.').slice(1).join('.')!;

--- a/source/components/files-edit.ts
+++ b/source/components/files-edit.ts
@@ -1,0 +1,173 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2024
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * Any code and/or API associated with OBSIDIAN behaves as stated in their distribution policy.
+ */
+
+import {
+    Modal,
+    ButtonComponent,
+    TextComponent,
+    TAbstractFile,
+    Setting,
+} from "obsidian";
+
+import UNITADE_PLUGIN from "./../main";
+import MODALES_LOCALE from "./../locales/modals.text";
+
+export class TFilesEdit extends Modal {
+    private _new_extension: string = 'md';
+
+    private _files: TAbstractFile[] = [];
+
+    private _integration: boolean;
+
+    constructor(
+        private plugin: UNITADE_PLUGIN,
+        private target: TAbstractFile[]
+    ) {
+        super(plugin.app);
+
+        this.target ??= [this.plugin.app.vault.getRoot()];
+
+        for (const item of target) {
+            this._files.push(item);
+        }
+
+        this._integration = false;
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+
+        const form = contentEl.createEl("div");
+        const disp = contentEl.createEl("span");
+
+        const input = new TextComponent(form);
+
+        contentEl.style.cssText =
+            `
+            display:          flex;
+            align-items:    center;
+            flex-direction: column;
+            `;
+        disp.style.cssText =
+            `
+            flex-grow:       1;
+            font-weight:  bold;
+            margin-top:   10px;
+            margin-right: 10px;
+            margin-bottom: 5px;
+            text-align: center;
+            `;
+        form.style.cssText =
+            `
+            display:       flex;
+            align-items: center;
+            `;
+        input.inputEl.style.cssText =
+            `
+            flex-grow:       1;
+            margin-right: 10px;
+            `;
+
+        disp.innerHTML = this.__generateDisplayInfo();
+
+        input.inputEl.addEventListener("keypress", (e) => {
+            if (e.key === "Enter") {
+                this.__submit();
+            } else if (e.key === "Escape") {
+                this.close();
+            }
+        });
+
+        input.setValue(this._new_extension);
+        input.onChange((value) => {
+            this._new_extension = value.startsWith(".") ? value.slice(1) : value;
+
+            disp.innerHTML = this.__generateDisplayInfo();
+        });
+
+        new ButtonComponent(form)
+            .setCta()
+            .setIcon('pencil')
+            .setButtonText("Edit")
+            .onClick(() => (this.__submit()));
+
+        new Setting(contentEl)
+            .setName(MODALES_LOCALE.gtToggle1().name)
+            .setDesc(MODALES_LOCALE.gtToggle1().desc)
+            .addToggle(toggle => {
+                toggle
+                    .setValue(this._integration)
+                    .onChange(async (value) => {
+                        this._integration = value;
+                    });
+
+                return toggle;
+            });
+    }
+
+    onClose() {
+        const { contentEl } = this;
+
+        contentEl.empty();
+    }
+
+    private async __submit() {
+        this.close();
+
+        if (this._integration) {
+            let next = {
+                ...this.plugin.settings,
+            };
+
+            next.extensions += `;${this._new_extension}`;
+
+            this.plugin.uptSettings(next);
+        }
+
+        this._files.forEach(async (file) => {
+            const filename = file.path.split('/').last()!
+            const filepath = file.path.split('/').slice(0, -1).join('/');
+
+            const name = filename.split('.').first()!;
+
+            await this.app.vault.rename(file, this.__pathgen(filepath, name));
+        });
+    }
+
+    private __pathgen(path: string, name: string): string {
+        return path + "/" + name + (!!this._new_extension ? "." : "") + this._new_extension;
+    }
+
+    private __generateDisplayInfo(): string {
+        return this._files.map(file => {
+            const filename = file.path.split('/').last()!;
+            const filepath = file.path.split('/').slice(0, -1).join('/');
+            const extension = filename.split('.').slice(1).join('.')!;
+            const name = filename.split('.').first()!;
+            return `<div>${filepath}/${name}.${extension}</div>`;
+        }).join('');
+    }
+} 

--- a/source/components/files-edit.ts
+++ b/source/components/files-edit.ts
@@ -161,7 +161,7 @@ export class TFilesEdit extends Modal {
             const filepath = file.path.split('/').slice(0, -1).join('/');
             const extension = filename.split('.').slice(1).join('.')!;
             const name = filename.split('.').first()!;
-            return `<div>${filepath}/${name}.${extension}</div>`;
+            return `<div>${filepath}/${name}.${this._new_extension}</div>`;
         }).join('');
     }
 } 

--- a/source/components/files-rename.ts
+++ b/source/components/files-rename.ts
@@ -1,0 +1,156 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2024
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * Any code and/or API associated with OBSIDIAN behaves as stated in their distribution policy.
+ */
+
+import {
+    Modal,
+    ButtonComponent,
+    TextComponent,
+    TAbstractFile,
+    Setting,
+} from "obsidian";
+
+import UNITADE_PLUGIN from "./../main";
+import MODALES_LOCALE from "./../locales/modals.text";
+
+export class TFilesRename extends Modal {
+    private _new_name: string = '';
+
+    private _integration: boolean;
+
+    private _new_name_queue: string[] = [];
+
+    constructor(
+        private plugin: UNITADE_PLUGIN,
+        private target: TAbstractFile[]
+    ) {
+        super(plugin.app);
+
+        this.target ??= [this.plugin.app.vault.getRoot()];
+
+        this._integration = false;
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+
+        const form = contentEl.createEl("div");
+        const disp = contentEl.createEl("span");
+
+        const input = new TextComponent(form);
+
+        contentEl.style.cssText =
+            `
+            display:          flex;
+            align-items:    center;
+            flex-direction: column;
+            `;
+        disp.style.cssText =
+            `
+            flex-grow:       1;
+            font-weight:  bold;
+            margin-top:   10px;
+            margin-right: 10px;
+            margin-bottom: 5px;
+            text-align: center;
+            `;
+        form.style.cssText =
+            `
+            display:       flex;
+            align-items: center;
+            `;
+        input.inputEl.style.cssText =
+            `
+            flex-grow:       1;
+            margin-right: 10px;
+            `;
+
+        disp.innerHTML = this.__generateDisplayInfo();
+
+        input.inputEl.addEventListener("keypress", (e) => {
+            if (e.key === "Enter") {
+                this.__submit();
+            } else if (e.key === "Escape") {
+                this.close();
+            }
+        });
+
+        input.setValue(this._new_name);
+        input.onChange((value) => {
+            this._new_name = value.startsWith(".") ? value.slice(1) : value;
+
+            disp.innerHTML = this.__generateDisplayInfo();
+        });
+
+        new ButtonComponent(form)
+            .setCta()
+            .setIcon('pencil')
+            .setButtonText("Rename")
+            .onClick(() => (this.__submit()));
+    }
+
+    onClose() {
+        const { contentEl } = this;
+
+        contentEl.empty();
+    }
+
+    private async __submit() {
+        this.close();
+
+        this.target.forEach(async (file) => {
+            const filename = file.path.split('/').last()!
+            const filepath = file.path.split('/').slice(0, -1).join('/');
+
+            const extension = filename.split('.').last()!;
+
+            const destination = this.__pathgen(filepath, extension);
+
+            this._new_name_queue.push(destination);
+
+            await this.app.vault.rename(file, destination);
+        });
+    }
+
+    private __pathgen(path: string, extension: string): string {
+        let fin_name = this._new_name;
+
+        if (this._new_name_queue.first()) {
+            fin_name = `${this._new_name} (${this._new_name_queue.length})`;
+        }
+
+        return path + "/" + fin_name + (!!extension ? "." : "") + extension;
+    }
+
+    private __generateDisplayInfo(): string {
+        return this.target.map(file => {
+            const filename = file.path.split('/').last()!;
+            const filepath = file.path.split('/').slice(0, -1).join('/');
+            const extension = filename.split('.').slice(1).join('.')!;
+            const name = filename.split('.').first()!;
+            return `<div>${filepath}/${this._new_name}.${extension}</div>`;
+        }).join('');
+    }
+} 

--- a/source/main.ts
+++ b/source/main.ts
@@ -62,6 +62,7 @@ import {
     gencase,
     parsegroup
 } from './utils/functions';
+import { TFilesRename } from './components/files-rename';
 
 export default class UNITADE_PLUGIN extends Plugin {
     private _settings: UNITADE_SETTINGS = DEFAULT_SETTINGS;
@@ -219,15 +220,25 @@ export default class UNITADE_PLUGIN extends Plugin {
 
     private __ctxEditExts(): EventRef {
         return this.app.workspace.on('files-menu', (menu, files) => {
-            menu.addItem((item) => {
-                item.setTitle('Edit multiple extensions');
-                item
-                    .setIcon('pencil')
-                    .onClick(() => {
-                        new TFilesEdit(this, files)
-                            .open();
-                    });
-            });
+            menu
+                .addItem((item) => {
+                    item.setTitle('Edit multiple extensions');
+                    item
+                        .setIcon('pencil')
+                        .onClick(() => {
+                            new TFilesEdit(this, files)
+                                .open();
+                        });
+                })
+                .addItem((item) => {
+                    item.setTitle('Rename multiple files');
+                    item
+                        .setIcon('pencil')
+                        .onClick(() => {
+                            new TFilesRename(this, files)
+                                .open();
+                        })
+                });
         });
     }
 

--- a/source/main.ts
+++ b/source/main.ts
@@ -47,7 +47,9 @@ import {
 import {
     TFileCreate
 } from './components/file-create';
-
+import {
+    TFilesEdit
+} from './components/files-edit';
 import {
     TFolderEdit
 } from './components/folder-edit';
@@ -176,6 +178,7 @@ export default class UNITADE_PLUGIN extends Plugin {
         this.app.workspace.layoutReady ? this.ltReady(this.app) : this.app.workspace.on('layout-change', () => { this.ltReady(this.app); });
 
         this.registerEvent(this.__ctxEditExt());
+        this.registerEvent(this.__ctxEditExts());
 
         this.__apply();
     }
@@ -211,6 +214,19 @@ export default class UNITADE_PLUGIN extends Plugin {
                             }
                         });
                 });
+        });
+    }
+
+    private __ctxEditExts(): EventRef {
+        return this.app.workspace.on('files-menu', (menu, files) => {
+            menu.addItem((item) => {
+                item.setTitle('Edit multiple extensions');
+                item
+                    .setIcon('pencil')
+                    .onClick(() => {
+                        new TFilesEdit(this, files);
+                    })
+            });
         });
     }
 

--- a/source/main.ts
+++ b/source/main.ts
@@ -224,8 +224,9 @@ export default class UNITADE_PLUGIN extends Plugin {
                 item
                     .setIcon('pencil')
                     .onClick(() => {
-                        new TFilesEdit(this, files);
-                    })
+                        new TFilesEdit(this, files)
+                            .open();
+                    });
             });
         });
     }


### PR DESCRIPTION
<!-- 
 This is an example template for PRs of any repository, in case of need, it could be 
 changed for other direct purposes or project's and organization's infrastructure.
 -->

PRs: add modals to rename or edit extensions of multiple files
============================

Before writing anything about your changes in this PR, checklist this items:

- [x] Agreed with current version of [code of conduct](./../CODE_OF_CONDUCT.md).
- [x] Read and followed current version of [“issue policy”](./../../docs/github/ISSUES/ISSUE_POLICY.md).
- [x] Read and followed current version of [“commit convention”](./../../docs/github/COMMIT_CONVENTION.md).

By agreeding and following this project's documentation, you are reminded that your's commit and styling of changes must follow this project's documentation, in case of “de-followization”, there are two ways before you make sure to publishing your PR:

1. In case of “de-followization” of commit's styling convention, you can amend them (change their message and description signatures):

```powershell
git commit --amend -m "MESSAGE" -m "DESCRIPTION"
```

For amending old commit, see the stackoverflow question[^1], more about changing commits in official docs for github: \
https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message/

[^1]: https://stackoverflow.com/questions/17338792/amending-old-commit/

2. In case of “de-followization” of coding, documentation and etc. files, you can just refactor everything you need by following styling guidelines of project.

### Changes with that PR
<!-- CHANGES BLOCK: 
 -->

Please, write below every changes you made:

...

### Process of testing for that PR
<!-- TESTING BLOCK: 
 -->

- Was testing process initiated via this PR?\
  answer (y/n): (y);
- If testing was done, type below the procedures you make: \
  Used modals on different arrays of files under different cases (different extensions, names, folders and etc.) imitating user experience.

### Additional context for that PR

...
