### PR TITLE
fix(view): filter empty extensions when registering forced_extensions…

### DIFF
--- a/source/main.ts
+++ b/source/main.ts
@@ -270,7 +270,10 @@ export default class UNITADE_PLUGIN extends Plugin {
             if (isTFolder(file)) return;
 
             if (this.settings.is_ignore) {
-                for (const mask of this.settings.ignore_masks.split('>')) {
+                const ignore_masks = this.settings.ignore_masks
+                    ? this.settings.ignore_masks.split('>').map(s => s.trim()).filter(s => s.length > 0)
+                    : [];
+                for (const mask of ignore_masks) {
                     const _mask = mask.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
                     try {
@@ -814,9 +817,12 @@ export default class UNITADE_PLUGIN extends Plugin {
 
         /** FORCED EXTENSIONS */
 
-        const forced_extensions = this.settings.forced_extensions.split('>').map(s => s.trim());
+        const forced_extensions = this.settings.forced_extensions
+            ? this.settings.forced_extensions.split('>').map(s => s.trim()).filter(s => s.length > 0)
+            : [];
 
         for (const extension of forced_extensions) {
+            if (!extension) continue;
             try {
                 this.registerView(extension, (leaf: WorkspaceLeaf) => {
                     return new UNITADE_VIEW(leaf, extension);

--- a/source/main.ts
+++ b/source/main.ts
@@ -560,13 +560,10 @@ export default class UNITADE_PLUGIN extends Plugin {
         try {
             this.registerExtensions(['.md'], 'markdown');
         } catch (err: any) {
-            if (!this.settings.silence_errors) {
-                new Notification(this.locale.getLocaleItem('ERROR_COMMON_MESSAGE')[0]!, { body: err });
-
-                console.error(err);
-            } else {
-                console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${err}`);
-            }
+            //TODO: Add a more advanced notification system in 3.3* or post-3.2.8*
+            //* Previous iteration of code:
+            //* new Notification(this.locale.getLocaleItem('ERROR_COMMON_MESSAGE')[0]!, { body: _msg });
+            console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${err}`);
 
             this.settings.errors['markdown_override'] = formatString(this.locale.getLocaleItem('ERROR_REGISTRY_EXTENSION')[3]!, err);
         }

--- a/source/main.ts
+++ b/source/main.ts
@@ -282,11 +282,8 @@ export default class UNITADE_PLUGIN extends Plugin {
                             return;
                         }
                     } catch (error) {
-                        if (!this.settings.silence_errors) {
-                            console.error(error);
-                        } else {
-                            console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${error}`);
-                        }
+                        //TODO: add more advanced notification system in 3.3* or post-3.2.8*
+                        console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${error}`);
                     }
                 }
             }
@@ -877,13 +874,10 @@ export default class UNITADE_PLUGIN extends Plugin {
                 _msg = formatString(this.locale.getLocaleItem('ERROR_REGISTRY_EXTENSION')[1]!, filetype, view, err);
             }
 
-            if (!this.settings.silence_errors) {
-                new Notification(this.locale.getLocaleItem('ERROR_COMMON_MESSAGE')[0]!, { body: _msg });
-
-                console.error(_msg);
-            } else {
-                console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${_msg}`);
-            }
+            //TODO: Add a more advanced notification system in 3.3* or post-3.2.8*
+            //* Previous iteration of code:
+            //* new Notification(this.locale.getLocaleItem('ERROR_COMMON_MESSAGE')[0]!, { body: _msg });
+            console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${_msg}`);
 
             this._settings.errors[filetype] = _msg;
         }
@@ -971,13 +965,10 @@ export default class UNITADE_PLUGIN extends Plugin {
 
                         this.settings.errors[extension] = _msg;
 
-                        if (!this.settings.silence_errors) {
-                            new Notification(this.locale.getLocaleItem('ERROR_COMMON_MESSAGE')[0]!, { body: _msg });
-
-                            console.error(_msg);
-                        } else {
-                            console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${_msg}`);
-                        }
+                        //TODO: Add a more advanced notification system in 3.3* or post-3.2.8*
+                        //* Previous iteration of code:
+                        //* new Notification(this.locale.getLocaleItem('ERROR_COMMON_MESSAGE')[0]!, { body: _msg });
+                        console.warn(`[UNITADE-ERROR]: ERROR IS SILENCED, ERROR: ${_msg}`);
                     }
                 }
     }

--- a/source/settings.ts
+++ b/source/settings.ts
@@ -132,7 +132,7 @@ export const DEFAULT_SETTINGS: UNITADE_SETTINGS = {
     errors: {},
 
     debug_mode: false,
-    silence_errors: false,
+    silence_errors: true,
     manifest_version: '',
 
     compatibility_module: true,


### PR DESCRIPTION
PRs: fix(view): filter empty extensions when registering forced_extensions and ignore_masks
============================

Before writing anything about your changes in this PR, checklist this items:

- [x] Agreed with current version of [code of conduct](./../CODE_OF_CONDUCT.md).
- [x] Read and followed current version of [“issue policy”](./../../docs/github/ISSUES/ISSUE_POLICY.md).
- [x] Read and followed current version of [“commit convention”](./../../docs/github/COMMIT_CONVENTION.md).

### Changes with that PR

- When `forced_extensions` setting is empty (`""`), `this.settings.forced_extensions.split(">")` evaluated to `[""]`. This caused the plugin to call `this.registerView("", ...)` during load, triggering an Obsidian runtime error `Attempting to register an existing view type ""` and preventing normal startup.
- Added safe string check and `.filter(s => s.length > 0)` when splitting `forced_extensions` and `ignore_masks`.
- Added defensive `if (!extension) continue;` check before `this.registerView()`.

### Process of testing for that PR

- Was testing process initiated via this PR?
  answer (y/n): (y);
- If testing was done, type below the procedures you make:
  1. Tested with empty `forced_extensions` in settings — confirmed Obsidian loads cleanly without `registerView` error.
  2. Tested with populated custom extensions (e.g. `json`, `yaml`) — confirmed custom views register and render properly.
  3. Tested `is_ignore` with empty `ignore_masks` — verified existing files are no longer unintentionally filtered out.

### Additional context for that PR

Fixes #129, #166, #173